### PR TITLE
fix/revise-song-column-name

### DIFF
--- a/src/main/java/site/mutopia/server/domain/song/entity/SongEntity.java
+++ b/src/main/java/site/mutopia/server/domain/song/entity/SongEntity.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SongEntity {
     @Id
-    @Column(name = "id")
+    @Column(name = "song_id")
     private String id;
 
     @Column(name = "title")


### PR DESCRIPTION
개발 DB에 song_id로 되어있는 데이터가 있고, 다른 entity에서도 song_id로 join되는 부분이 있어서 song_id로 수정하였습니다.