### PR TITLE
fix: find trackInfo with new songId

### DIFF
--- a/src/main/java/site/mutopia/server/domain/song/dto/SongInfoDto.java
+++ b/src/main/java/site/mutopia/server/domain/song/dto/SongInfoDto.java
@@ -3,6 +3,7 @@ package site.mutopia.server.domain.song.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import site.mutopia.server.domain.song.entity.SongEntity;
 
 @Getter
 @Setter
@@ -19,4 +20,20 @@ public class SongInfoDto {
     Long likeCount;
     Boolean isLiked;
     Long myRating;
+
+    public static SongInfoDto fromEntity(SongEntity entity){
+        return new SongInfoDto(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getAlbum().getId(),
+                entity.getAlbum().getName(),
+                entity.getAlbum().getCoverImageUrl(),
+                entity.getAlbum().getArtistName(),
+                0L,
+                entity.getAverageRating(),
+                0L,
+                false,
+                0L
+        );
+    }
 }

--- a/src/main/java/site/mutopia/server/spotify/SpotifyApi.java
+++ b/src/main/java/site/mutopia/server/spotify/SpotifyApi.java
@@ -5,11 +5,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import site.mutopia.server.global.error.exception.EntityNotFoundException;
 import site.mutopia.server.spotify.dto.PagedTracks;
 import site.mutopia.server.spotify.dto.SearchAlbumsDto;
 import site.mutopia.server.spotify.dto.item.Albums;
 import site.mutopia.server.spotify.dto.track.SearchTracksDto;
 import site.mutopia.server.spotify.dto.track.Tracks;
+import site.mutopia.server.spotify.dto.trackinfo.TrackInfo;
 
 @Slf4j
 @Component
@@ -73,6 +76,18 @@ public class SpotifyApi {
                         .build(albumId))
                 .retrieve()
                 .bodyToMono(PagedTracks.class)
+                .block();
+    }
+
+    public TrackInfo getTrackInfo(String trackId){
+        return client.get()
+                .uri(uriBuilder -> uriBuilder.path("/tracks/{id}")
+                        .queryParam("market", "KR")
+                        .queryParam("locale", "ko_KR")
+                        .build(trackId))
+                .retrieve()
+                .bodyToMono(TrackInfo.class)
+                .onErrorResume(sub -> Mono.empty())
                 .block();
     }
 

--- a/src/main/java/site/mutopia/server/spotify/convertor/DomainConvertor.java
+++ b/src/main/java/site/mutopia/server/spotify/convertor/DomainConvertor.java
@@ -6,6 +6,8 @@ import site.mutopia.server.spotify.dto.item.Item;
 import site.mutopia.server.spotify.dto.item.Track;
 import site.mutopia.server.spotify.dto.track.TrackAlbumInfo;
 import site.mutopia.server.spotify.dto.track.TrackSearch;
+import site.mutopia.server.spotify.dto.trackinfo.TrackInfo;
+import site.mutopia.server.spotify.dto.trackinfo.TrackInfoAlbum;
 
 
 public class DomainConvertor {
@@ -47,6 +49,26 @@ public class DomainConvertor {
                 .coverImageUrl(item.images.get(0).url)
                 .releaseDate(item.release_date)
                 .length(null)
+                .build();
+    }
+
+    public static AlbumEntity toDomain(TrackInfoAlbum album){
+        return AlbumEntity.builder()
+                .id(album.id)
+                .name(album.name)
+                .artistName(album.artists.get(0).name)
+                .coverImageUrl(album.images.get(0).url)
+                .releaseDate(album.release_date)
+                .length(null)
+                .build();
+    }
+
+    public static SongEntity toDomain(TrackInfo trackInfo, String albumId) {
+        return SongEntity.builder()
+                .id(trackInfo.id)
+                .title(trackInfo.name)
+                .trackNumber(0)
+                .duration(trackInfo.duration_ms / 1000)
                 .build();
     }
 

--- a/src/main/java/site/mutopia/server/spotify/dto/trackinfo/Artist.java
+++ b/src/main/java/site/mutopia/server/spotify/dto/trackinfo/Artist.java
@@ -1,0 +1,8 @@
+package site.mutopia.server.spotify.dto.trackinfo;
+public class Artist{
+    public String href;
+    public String id;
+    public String name;
+    public String type;
+    public String uri;
+}

--- a/src/main/java/site/mutopia/server/spotify/dto/trackinfo/Image.java
+++ b/src/main/java/site/mutopia/server/spotify/dto/trackinfo/Image.java
@@ -1,0 +1,4 @@
+package site.mutopia.server.spotify.dto.trackinfo;
+public class Image{
+    public String url;
+}

--- a/src/main/java/site/mutopia/server/spotify/dto/trackinfo/TrackInfo.java
+++ b/src/main/java/site/mutopia/server/spotify/dto/trackinfo/TrackInfo.java
@@ -1,0 +1,13 @@
+package site.mutopia.server.spotify.dto.trackinfo;
+
+import java.util.ArrayList;
+
+public class TrackInfo{
+    public TrackInfoAlbum album;
+    public ArrayList<Artist> artists;
+    public int duration_ms;
+    public String id;
+    public String name;
+    public String type;
+    public String uri;
+}

--- a/src/main/java/site/mutopia/server/spotify/dto/trackinfo/TrackInfoAlbum.java
+++ b/src/main/java/site/mutopia/server/spotify/dto/trackinfo/TrackInfoAlbum.java
@@ -1,0 +1,13 @@
+package site.mutopia.server.spotify.dto.trackinfo;
+
+import java.util.ArrayList;
+
+public class TrackInfoAlbum {
+    public ArrayList<Artist> artists;
+    public String id;
+    public ArrayList<Image> images;
+    public String name;
+    public String release_date;
+    public String type;
+    public String uri;
+}

--- a/src/test/java/site/mutopia/server/album/repository/TrackInfoAlbumRepositoryTest.java
+++ b/src/test/java/site/mutopia/server/album/repository/TrackInfoAlbumRepositoryTest.java
@@ -2,7 +2,7 @@ package site.mutopia.server.album.repository;
 
 import org.junit.jupiter.api.Test;
 
-class AlbumRepositoryTest {
+class TrackInfoAlbumRepositoryTest {
 
     @Test
     void findAlbumById() {

--- a/src/test/java/site/mutopia/server/domain/albumLike/controller/TrackInfoAlbumLikeControllerTest.java
+++ b/src/test/java/site/mutopia/server/domain/albumLike/controller/TrackInfoAlbumLikeControllerTest.java
@@ -46,7 +46,7 @@ import static site.mutopia.server.util.ReflectionUtil.setFieldValue;
 })
 @Import({AlbumLikeService.class, TestSecurityConfig.class})
 @MockBean(JpaMetamodelMappingContext.class)
-class AlbumLikeControllerTest {
+class TrackInfoAlbumLikeControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -78,7 +78,7 @@ class AlbumLikeControllerTest {
     }
 
     @Nested
-    class ToggleLikeToAlbum {
+    class ToggleLikeToTrackInfoAlbum {
 
         @Test
         void 원래_좋아요가_꺼져_있었는데_좋아요를_누른_경우() throws Exception {
@@ -138,7 +138,7 @@ class AlbumLikeControllerTest {
 
 
     @Nested
-    class GetAlbumLikeStatus {
+    class GetTrackInfoAlbumLikeStatus {
 
         @Test
         void 로그인한_사용자에_대한_앨범_좋아요_상태를_반환해야한다_좋아요_눌린_경우() throws Exception {

--- a/src/test/java/site/mutopia/server/domain/albumReview/controller/TrackInfoAlbumReviewControllerTest.java
+++ b/src/test/java/site/mutopia/server/domain/albumReview/controller/TrackInfoAlbumReviewControllerTest.java
@@ -50,7 +50,7 @@ import static site.mutopia.server.util.ReflectionUtil.setFieldValue;
 })
 @Import({AlbumReviewService.class, TestSecurityConfig.class})
 @MockBean(JpaMetamodelMappingContext.class)
-class AlbumReviewControllerTest {
+class TrackInfoAlbumReviewControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -85,7 +85,7 @@ class AlbumReviewControllerTest {
     }
 
     @Nested
-    class SaveAlbumReview {
+    class SaveTrackInfoAlbumReview {
 
         @Test
         void shouldCreateAlbumReviewWhenRequestIsValid() throws Exception {
@@ -196,7 +196,7 @@ class AlbumReviewControllerTest {
     }
 
     @Nested
-    class GetAlbumReviewByAlbumReviewId {
+    class GetAlbumReviewByTrackInfoAlbumReviewId {
 
         @Test
         void shouldReturnAlbumReviewWhenUserLoggedInAndUserLikesOwnReview() throws Exception {

--- a/src/test/java/site/mutopia/server/spotify/SpotifyApiTest.java
+++ b/src/test/java/site/mutopia/server/spotify/SpotifyApiTest.java
@@ -46,4 +46,11 @@ class SpotifyApiTest {
         assertNotNull(tracks);
     }
 
+    @Test
+    void getTrackInfo() {
+        var trackInfo = spotifyApi.getTrackInfo("6bvZRLLkBKkmgpBJTTj3QK");
+        log.info("trackInfo: {}", trackInfo);
+        assertNotNull(trackInfo);
+    }
+
 }


### PR DESCRIPTION
trending api에서 알게된 새로운 songId는 DB에 적재되지 않음에 따라서.
[/song/info/{songId}] 요청시 DB에 존재하지 않으면 spotify에 조회하는 로직 추가